### PR TITLE
added a toggle to either generate new keys only, or to generate and deploy them immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ See also comments and default values in role's file [`default/main.yml`](default
 
 ### Postfix configuration variables
 
-  Variable     |   Default value   |   Description  |
+|  Variable     |   Default value   |   Description  |
 |:-------------------:|:------------------------:|:------------:|
 | `dkim_postfix_config_file:` | /etc/postfix/main.cf | Postfix main configuration file |
 | `dkim_postfix_config:` | see [`vars/main.yml`](vars/main.yml) | List of parameters to be defined in Postfix configuration. Default configuration ensures opendkim is set up as a milter of Postfix to sign mails. You can define additional Postfix parameters using a list union. |
 
-### operational parameters
+### Operational parameters
 
 |  Variable     |   Default value   |   Description  |
 |:-------------------:|:------------------------:|:------------:|

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ See also comments and default values in role's file [`default/main.yml`](default
 | `dkim_postfix_config_file:` | /etc/postfix/main.cf | Postfix main configuration file |
 | `dkim_postfix_config:` | see [`vars/main.yml`](vars/main.yml) | List of parameters to be defined in Postfix configuration. Default configuration ensures opendkim is set up as a milter of Postfix to sign mails. You can define additional Postfix parameters using a list union. |
 
+### operational parameters
+
+|  Variable     |   Default value   |   Description  |
+|:-------------------:|:------------------------:|:------------:|
+| `dkim_generate_only:` | false | Only (false) generate DKIM keys and display records to provide the opportunity for DNS publication, or: (true) generate, display and immediately deploy to opendkim plus restart opendkim in the same run |
+
+
 ## Example playbook
 ```yaml
 ---

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,4 +50,7 @@ dkim_postfix_config: '{{ dkim_postfix_config_default }}'
 #sendmail config file and folder
 dkim_sendmail_config_folder: /etc/mail/
 dkim_sendmail_config_file: "{{ dkim_sendmail_config_folder }}sendmail.mc"
-...
+
+# generate and deploy certificates, or just generate, and keep existing config
+# this allows time to generate keys, publish them in dns, and then do a deploy
+dkim_generate_only: false

--- a/tasks/opendkim.yml
+++ b/tasks/opendkim.yml
@@ -41,6 +41,7 @@
   template:
     src: KeyTable.j2
     dest: '{{ dkim_opendkim_config_dir }}/KeyTable'
+  when: not dkim_generate_only
   notify:
    - restart opendkim
 
@@ -48,6 +49,7 @@
   template:
     src: SigningTable.j2
     dest: '{{ dkim_opendkim_config_dir }}/SigningTable'
+  when: not dkim_generate_only
   notify:
    - restart opendkim
 


### PR DESCRIPTION
As requested: I fetched upstream, rebased, and pushed again. This PR contains only the toggle to choose to generate_only, or to generate and deploy. Of course defaulting to the current behaviour.